### PR TITLE
feat: show Telegram WebApp attributes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,101 +1,124 @@
+:root {
+  color-scheme: light;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: linear-gradient(135deg, #eef2ff 0%, #f8fafc 100%);
+  color: #1f2937;
+}
+
 .app {
   min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 2rem 1.5rem;
+  padding: 2.5rem 1.5rem;
 }
 
 .card {
-  width: min(100%, 420px);
+  width: min(100%, 760px);
   background-color: #ffffff;
-  border-radius: 20px;
-  padding: 2.5rem 2rem;
-  box-shadow: 0 18px 40px rgba(44, 62, 80, 0.12);
+  border-radius: 24px;
+  padding: 2.5rem 2.25rem;
+  box-shadow: 0 24px 50px rgba(15, 23, 42, 0.12);
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
 .title {
   margin: 0;
-  font-size: 1.75rem;
+  font-size: 2rem;
   font-weight: 700;
   text-align: center;
+  color: #111827;
 }
 
 .subtitle {
   margin: 0;
-  color: #5f6c7b;
+  color: #6b7280;
   font-size: 1rem;
   text-align: center;
 }
 
-.form {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+.subtitle code {
+  font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  background-color: rgba(79, 70, 229, 0.08);
+  padding: 0.15rem 0.35rem;
+  border-radius: 0.4rem;
 }
 
-.field-label {
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: #3a4756;
-}
-
-.field-input {
-  padding: 0.75rem 1rem;
-  border: 1px solid rgba(90, 105, 120, 0.35);
-  border-radius: 12px;
-  font-size: 1rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.field-input:focus {
-  outline: none;
-  border-color: #2a73ff;
-  box-shadow: 0 0 0 4px rgba(42, 115, 255, 0.15);
-}
-
-.submit-button {
-  margin-top: 0.5rem;
-  padding: 0.75rem 1.25rem;
-  border: none;
-  border-radius: 12px;
-  font-size: 1rem;
-  font-weight: 600;
-  color: #ffffff;
-  background: linear-gradient(135deg, #2a73ff 0%, #5b9dff 100%);
-  cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
-}
-
-.submit-button:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 20px rgba(42, 115, 255, 0.25);
-}
-
-.submit-button:active {
-  transform: translateY(0);
-  box-shadow: none;
-}
-
-.greeting {
+.attributes-list {
   margin: 0;
-  padding: 0.75rem 1rem;
-  border-radius: 12px;
-  background-color: rgba(42, 115, 255, 0.1);
-  color: #1d3a7c;
-  font-weight: 600;
-  text-align: center;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
 }
 
-@media (max-width: 480px) {
+.attribute {
+  display: grid;
+  gap: 0.5rem;
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  background-color: rgba(37, 99, 235, 0.06);
+  border: 1px solid rgba(37, 99, 235, 0.12);
+}
+
+.attribute-key {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #1d4ed8;
+  word-break: break-word;
+}
+
+.attribute-value {
+  margin: 0;
+}
+
+.attribute-value pre {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  color: #1f2937;
+}
+
+.empty-state {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  background-color: rgba(15, 23, 42, 0.05);
+  color: #334155;
+  text-align: center;
+  line-height: 1.5;
+}
+
+.empty-state code {
+  font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  background-color: rgba(15, 23, 42, 0.07);
+  padding: 0.15rem 0.35rem;
+  border-radius: 0.4rem;
+}
+
+@media (max-width: 600px) {
   .card {
     padding: 2rem 1.5rem;
+    border-radius: 20px;
   }
 
   .title {
-    font-size: 1.5rem;
+    font-size: 1.65rem;
+  }
+
+  .attribute {
+    padding: 0.85rem 1rem;
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,44 +1,109 @@
-import { FormEvent, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import './App.css'
 
-function App() {
-  const [fullName, setFullName] = useState('')
-  const [greetingName, setGreetingName] = useState<string | null>(null)
+type AttributeItem = {
+  key: string
+  value: string
+}
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const trimmedName = fullName.trim()
-    setGreetingName(trimmedName ? trimmedName : null)
+const formatValue = (value: unknown): string => {
+  if (typeof value === 'function') {
+    return '[function]'
   }
+
+  if (typeof value === 'bigint') {
+    return value.toString()
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    const seen = new WeakSet<object>()
+
+    try {
+      const json = JSON.stringify(
+        value,
+        (_key, nestedValue) => {
+          if (typeof nestedValue === 'function') {
+            return '[function]'
+          }
+
+          if (typeof nestedValue === 'bigint') {
+            return nestedValue.toString()
+          }
+
+          if (typeof nestedValue === 'object' && nestedValue !== null) {
+            if (seen.has(nestedValue as object)) {
+              return '[Circular]'
+            }
+            seen.add(nestedValue as object)
+          }
+
+          return nestedValue
+        },
+        2
+      )
+
+      return json
+    } catch (error) {
+      console.error('Failed to serialize value from Telegram.WebApp', error)
+      return '[unserializable object]'
+    }
+  }
+
+  if (value === undefined) {
+    return 'undefined'
+  }
+
+  return String(value)
+}
+
+function App() {
+  const [webApp, setWebApp] = useState<Record<string, unknown> | null>(null)
+
+  useEffect(() => {
+    const telegramWebApp = window.Telegram?.WebApp ?? null
+    setWebApp(telegramWebApp ? { ...telegramWebApp } : null)
+  }, [])
+
+  const attributes = useMemo<AttributeItem[]>(() => {
+    if (!webApp) {
+      return []
+    }
+
+    return Object.entries(webApp)
+      .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
+      .map(([key, value]) => ({
+        key,
+        value: formatValue(value),
+      }))
+  }, [webApp])
 
   return (
     <main className="app">
       <section className="card">
-        <h1 className="title">Приветствие</h1>
-        <p className="subtitle">Введите своё ФИО, чтобы мы могли с вами поздороваться.</p>
+        <h1 className="title">Информация о Telegram Mini App</h1>
+        <p className="subtitle">
+          Ниже перечислены доступные атрибуты объекта <code>window.Telegram.WebApp</code>.
+        </p>
 
-        <form className="form" onSubmit={handleSubmit}>
-          <label className="field-label" htmlFor="fullName">
-            ФИО
-          </label>
-          <input
-            id="fullName"
-            className="field-input"
-            type="text"
-            placeholder="Например, Иванов Иван Иванович"
-            value={fullName}
-            onChange={(event) => setFullName(event.target.value)}
-            autoComplete="name"
-            required
-          />
-          <button className="submit-button" type="submit">
-            Поздороваться
-          </button>
-        </form>
-
-        {greetingName !== null && (
-          <p className="greeting" role="status" aria-live="polite">
-            Привет, {greetingName}!
+        {webApp ? (
+          <dl className="attributes-list">
+            {attributes.map(({ key, value }) => (
+              <div key={key} className="attribute">
+                <dt className="attribute-key">{key}</dt>
+                <dd className="attribute-value">
+                  <pre>{value}</pre>
+                </dd>
+              </div>
+            ))}
+          </dl>
+        ) : (
+          <p className="empty-state">
+            Объект <code>window.Telegram.WebApp</code> не обнаружен. Откройте приложение из Telegram, чтобы увидеть
+            данные Mini App.
           </p>
         )}
       </section>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,17 @@
 /// <reference types="vite/client" />
+
+declare global {
+  interface TelegramWebApp {
+    [key: string]: unknown
+  }
+
+  interface TelegramNamespace {
+    WebApp?: TelegramWebApp
+  }
+
+  interface Window {
+    Telegram?: TelegramNamespace
+  }
+}
+
+export {}


### PR DESCRIPTION
## Summary
- replace the greeting form with a panel that lists attributes from `window.Telegram.WebApp`
- add resilient serialization logic so complex values can be rendered safely
- refresh the layout and styling to highlight the Telegram Mini App information

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd7dc3ad2c83209017b96e7a70c9ae