### PR TITLE
feat: integrate url shortener client into mini app

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5,8 +5,8 @@
 body {
   margin: 0;
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background: linear-gradient(135deg, #eef2ff 0%, #f8fafc 100%);
-  color: #1f2937;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(99, 102, 241, 0.08));
+  color: #0f172a;
 }
 
 .app {
@@ -14,111 +14,313 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 2.5rem 1.5rem;
+  padding: 3rem 1.5rem;
+  background-color: var(--background-color, transparent);
+  transition: background-color 0.3s ease;
 }
 
-.card {
-  width: min(100%, 760px);
-  background-color: #ffffff;
-  border-radius: 24px;
-  padding: 2.5rem 2.25rem;
-  box-shadow: 0 24px 50px rgba(15, 23, 42, 0.12);
+.dashboard {
+  width: min(960px, 100%);
+  background-color: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(18px);
+  border-radius: 28px;
+  padding: 2.75rem 3rem;
+  box-shadow: 0 30px 70px rgba(15, 23, 42, 0.18);
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
+  gap: 2.5rem;
+}
+
+.dashboard__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
 }
 
 .title {
   margin: 0;
-  font-size: 2rem;
+  font-size: 2.25rem;
   font-weight: 700;
-  text-align: center;
-  color: #111827;
+  color: #0f172a;
 }
 
 .subtitle {
-  margin: 0;
-  color: #6b7280;
+  margin: 0.5rem 0 0;
+  color: #475569;
   font-size: 1rem;
-  text-align: center;
+  max-width: 38rem;
+  line-height: 1.5;
 }
 
-.subtitle code {
-  font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    'Liberation Mono', 'Courier New', monospace;
-  background-color: rgba(79, 70, 229, 0.08);
-  padding: 0.15rem 0.35rem;
-  border-radius: 0.4rem;
+.subtitle-accent {
+  font-weight: 600;
+  color: var(--accent-color, #2563eb);
 }
 
-.attributes-list {
+.shorten-form {
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.75rem;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.08), rgba(37, 99, 235, 0.08));
+  border: 1px solid rgba(59, 130, 246, 0.22);
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-field label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.form-field input {
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+  background-color: #ffffff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-field input:focus {
+  border-color: var(--accent-color, #2563eb);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+.form-field input:disabled {
+  background-color: #f1f5f9;
+  cursor: not-allowed;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.primary-button,
+.ghost-button,
+.danger-button {
+  border: none;
+  border-radius: 12px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.75rem 1.4rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+}
+
+.primary-button {
+  background: var(--accent-color, linear-gradient(135deg, #2563eb, #4338ca));
+  color: var(--accent-text-color, #ffffff);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.24);
+}
+
+.primary-button:disabled {
+  opacity: 0.65;
+  cursor: wait;
+}
+
+.primary-button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(37, 99, 235, 0.28);
+}
+
+.ghost-button {
+  background-color: rgba(15, 23, 42, 0.04);
+  color: #1e293b;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.ghost-button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.ghost-button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.12);
+}
+
+.danger-button {
+  background: linear-gradient(135deg, #ef4444, #dc2626);
+  color: #ffffff;
+}
+
+.danger-button:disabled {
+  opacity: 0.65;
+  cursor: wait;
+}
+
+.danger-button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(220, 38, 38, 0.28);
+}
+
+.error-banner {
+  padding: 0.95rem 1.1rem;
+  border-radius: 14px;
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+  border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+.links-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.links-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.links-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.links-counter {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background-color: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.links-list {
+  list-style: none;
   margin: 0;
   padding: 0;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
 }
 
-.attribute {
-  display: grid;
-  gap: 0.5rem;
-  padding: 1rem 1.25rem;
-  border-radius: 16px;
-  background-color: rgba(37, 99, 235, 0.06);
-  border: 1px solid rgba(37, 99, 235, 0.12);
+.link-item {
+  border-radius: 18px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  padding: 1.5rem;
+  background: #ffffff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.08);
 }
 
-.attribute-key {
-  margin: 0;
-  font-size: 0.95rem;
+.link-top-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.link-short {
+  font-size: 1.1rem;
   font-weight: 600;
-  color: #1d4ed8;
+  color: var(--accent-color, #2563eb);
+  text-decoration: none;
   word-break: break-word;
 }
 
-.attribute-value {
-  margin: 0;
+.link-short:hover {
+  text-decoration: underline;
 }
 
-.attribute-value pre {
-  margin: 0;
+.link-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.link-original {
+  font-size: 0.95rem;
+  color: #334155;
+  word-break: break-word;
+}
+
+.link-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
   font-size: 0.85rem;
-  line-height: 1.4;
-  white-space: pre-wrap;
-  word-break: break-word;
-  font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    'Liberation Mono', 'Courier New', monospace;
-  color: #1f2937;
+  color: #64748b;
+}
+
+.skeleton {
+  opacity: 0.7;
+}
+
+.skeleton-line {
+  height: 18px;
+  background: linear-gradient(90deg, rgba(226, 232, 240, 0.9), rgba(226, 232, 240, 0.4), rgba(226, 232, 240, 0.9));
+  border-radius: 10px;
+  background-size: 300px 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+.skeleton-line.short {
+  width: 45%;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: -100px 0;
+  }
+  100% {
+    background-position: 200px 0;
+  }
 }
 
 .empty-state {
   margin: 0;
-  padding: 1rem 1.25rem;
+  padding: 1.5rem;
   border-radius: 16px;
-  background-color: rgba(15, 23, 42, 0.05);
-  color: #334155;
+  background-color: rgba(15, 23, 42, 0.04);
+  color: #475569;
   text-align: center;
-  line-height: 1.5;
+  line-height: 1.6;
 }
 
-.empty-state code {
-  font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    'Liberation Mono', 'Courier New', monospace;
-  background-color: rgba(15, 23, 42, 0.07);
-  padding: 0.15rem 0.35rem;
-  border-radius: 0.4rem;
-}
+@media (max-width: 768px) {
+  .app {
+    padding: 2rem 1rem;
+  }
 
-@media (max-width: 600px) {
-  .card {
+  .dashboard {
     padding: 2rem 1.5rem;
-    border-radius: 20px;
+    border-radius: 22px;
   }
 
   .title {
-    font-size: 1.65rem;
+    font-size: 1.8rem;
   }
 
-  .attribute {
-    padding: 0.85rem 1rem;
+  .shorten-form {
+    padding: 1.25rem;
+  }
+
+  .link-item {
+    padding: 1.25rem;
+  }
+
+  .link-actions {
+    width: 100%;
+    justify-content: flex-start;
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,111 +1,308 @@
-import { useEffect, useMemo, useState } from 'react'
+import type { ChangeEvent, CSSProperties, FormEvent } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import './App.css'
+import { createShortLink, deleteShortLink, fetchShortLinks, ShortLink } from './api/urlShortener'
 
-type AttributeItem = {
-  key: string
-  value: string
+type FormState = {
+  url: string
+  alias: string
 }
 
-const formatValue = (value: unknown): string => {
-  if (typeof value === 'function') {
-    return '[function]'
+const defaultFormState: FormState = {
+  url: '',
+  alias: '',
+}
+
+const formatDate = (value?: string) => {
+  if (!value) {
+    return null
   }
 
-  if (typeof value === 'bigint') {
-    return value.toString()
+  const date = new Date(value)
+
+  if (Number.isNaN(date.getTime())) {
+    return null
   }
 
-  if (value instanceof Date) {
-    return value.toISOString()
+  return new Intl.DateTimeFormat('ru-RU', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date)
+}
+
+const resolveWebAppTheme = () => {
+  const theme = window.Telegram?.WebApp?.themeParams
+
+  if (!theme) {
+    return undefined
   }
 
-  if (typeof value === 'object' && value !== null) {
-    const seen = new WeakSet<object>()
-
-    try {
-      const json = JSON.stringify(
-        value,
-        (_key, nestedValue) => {
-          if (typeof nestedValue === 'function') {
-            return '[function]'
-          }
-
-          if (typeof nestedValue === 'bigint') {
-            return nestedValue.toString()
-          }
-
-          if (typeof nestedValue === 'object' && nestedValue !== null) {
-            if (seen.has(nestedValue as object)) {
-              return '[Circular]'
-            }
-            seen.add(nestedValue as object)
-          }
-
-          return nestedValue
-        },
-        2
-      )
-
-      return json
-    } catch (error) {
-      console.error('Failed to serialize value from Telegram.WebApp', error)
-      return '[unserializable object]'
-    }
+  return {
+    accentText: theme.button_text_color,
+    accent: theme.button_color,
+    background: theme.bg_color,
   }
-
-  if (value === undefined) {
-    return 'undefined'
-  }
-
-  return String(value)
 }
 
 function App() {
-  const [webApp, setWebApp] = useState<Record<string, unknown> | null>(null)
+  const [links, setLinks] = useState<ShortLink[]>([])
+  const [form, setForm] = useState<FormState>(defaultFormState)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [creating, setCreating] = useState(false)
+  const [copiedId, setCopiedId] = useState<string | null>(null)
+  const [deleting, setDeleting] = useState<Set<string>>(new Set())
+  const [webAppTheme, setWebAppTheme] = useState(resolveWebAppTheme)
 
   useEffect(() => {
-    const telegramWebApp = window.Telegram?.WebApp ?? null
-    setWebApp(telegramWebApp ? { ...telegramWebApp } : null)
+    if (window.Telegram?.WebApp) {
+      if (typeof window.Telegram.WebApp.ready === 'function') {
+        window.Telegram.WebApp.ready()
+      }
+      setWebAppTheme(resolveWebAppTheme())
+    }
   }, [])
 
-  const attributes = useMemo<AttributeItem[]>(() => {
-    if (!webApp) {
-      return []
+  const accentStyle = useMemo(() => {
+    if (!webAppTheme?.accent) {
+      return undefined
     }
 
-    return Object.entries(webApp)
-      .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
-      .map(([key, value]) => ({
-        key,
-        value: formatValue(value),
-      }))
-  }, [webApp])
+    return {
+      '--accent-color': webAppTheme.accent,
+      '--accent-text-color': webAppTheme.accentText ?? '#ffffff',
+      '--background-color': webAppTheme.background ?? '#f8fafc',
+    } as CSSProperties
+  }, [webAppTheme])
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const data = await fetchShortLinks()
+      setLinks(data)
+    } catch (fetchError) {
+      console.error(fetchError)
+      setError(fetchError instanceof Error ? fetchError.message : 'Не удалось загрузить ссылки')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  useEffect(() => {
+    if (!copiedId) {
+      return
+    }
+
+    const timeout = setTimeout(() => setCopiedId(null), 2500)
+
+    return () => clearTimeout(timeout)
+  }, [copiedId])
+
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target
+
+    setForm((prev) => ({
+      ...prev,
+      [name]: value,
+    }))
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (!form.url.trim()) {
+      setError('Введите ссылку, которую необходимо сократить')
+      return
+    }
+
+    setCreating(true)
+    setError(null)
+
+    try {
+      const newLink = await createShortLink({
+        url: form.url.trim(),
+        alias: form.alias.trim() || undefined,
+      })
+
+      setLinks((prev) => [newLink, ...prev.filter((item) => item.id !== newLink.id)])
+      setForm(defaultFormState)
+      setCopiedId(newLink.id)
+      try {
+        await navigator.clipboard?.writeText(newLink.shortUrl)
+      } catch (clipboardError) {
+        console.warn('Failed to copy newly created link', clipboardError)
+      }
+    } catch (createError) {
+      console.error(createError)
+      setError(createError instanceof Error ? createError.message : 'Не удалось создать короткую ссылку')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const handleCopy = async (link: ShortLink) => {
+    try {
+      await navigator.clipboard?.writeText(link.shortUrl)
+      setCopiedId(link.id)
+    } catch (copyError) {
+      console.error(copyError)
+      setError('Не удалось скопировать ссылку в буфер обмена')
+    }
+  }
+
+  const handleDelete = async (link: ShortLink) => {
+    setDeleting((prev) => {
+      const next = new Set(prev)
+      next.add(link.id)
+      return next
+    })
+    setError(null)
+
+    try {
+      await deleteShortLink(link.id)
+      setLinks((prev) => prev.filter((item) => item.id !== link.id))
+    } catch (deleteError) {
+      console.error(deleteError)
+      setError(deleteError instanceof Error ? deleteError.message : 'Не удалось удалить ссылку')
+    } finally {
+      setDeleting((prev) => {
+        const next = new Set(prev)
+        next.delete(link.id)
+        return next
+      })
+    }
+  }
 
   return (
-    <main className="app">
-      <section className="card">
-        <h1 className="title">Информация о Telegram Mini App</h1>
-        <p className="subtitle">
-          Ниже перечислены доступные атрибуты объекта <code>window.Telegram.WebApp</code>.
-        </p>
+    <main className="app" style={accentStyle}>
+      <section className="dashboard">
+        <header className="dashboard__header">
+          <div>
+            <h1 className="title">URL Shortener</h1>
+            <p className="subtitle">
+              Управляйте короткими ссылками сервиса{' '}
+              <span className="subtitle-accent">makar182/url-shortener</span> прямо из Mini App.
+            </p>
+          </div>
+          <button className="ghost-button" onClick={() => void refresh()} disabled={loading}>
+            {loading ? 'Обновление...' : 'Обновить'}
+          </button>
+        </header>
 
-        {webApp ? (
-          <dl className="attributes-list">
-            {attributes.map(({ key, value }) => (
-              <div key={key} className="attribute">
-                <dt className="attribute-key">{key}</dt>
-                <dd className="attribute-value">
-                  <pre>{value}</pre>
-                </dd>
-              </div>
-            ))}
-          </dl>
-        ) : (
-          <p className="empty-state">
-            Объект <code>window.Telegram.WebApp</code> не обнаружен. Откройте приложение из Telegram, чтобы увидеть
-            данные Mini App.
-          </p>
-        )}
+        <form className="shorten-form" onSubmit={handleSubmit}>
+          <div className="form-field">
+            <label htmlFor="url">Длинная ссылка</label>
+            <input
+              id="url"
+              name="url"
+              type="url"
+              placeholder="https://example.com/article"
+              value={form.url}
+              onChange={handleInputChange}
+              required
+              disabled={creating}
+            />
+          </div>
+          <div className="form-field">
+            <label htmlFor="alias">Пользовательский алиас (необязательно)</label>
+            <input
+              id="alias"
+              name="alias"
+              type="text"
+              placeholder="my-custom-alias"
+              value={form.alias}
+              onChange={handleInputChange}
+              disabled={creating}
+            />
+          </div>
+          <div className="form-actions">
+            <button className="primary-button" type="submit" disabled={creating}>
+              {creating ? 'Создание...' : 'Создать короткую ссылку'}
+            </button>
+          </div>
+        </form>
+
+        {error && <div className="error-banner">{error}</div>}
+
+        <section className="links-section">
+          <header className="links-header">
+            <h2>Ваши ссылки</h2>
+            <span className="links-counter">{links.length}</span>
+          </header>
+
+          {loading && links.length === 0 ? (
+            <ul className="links-list skeleton">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <li key={index} className="link-item">
+                  <div className="skeleton-line" />
+                  <div className="skeleton-line short" />
+                </li>
+              ))}
+            </ul>
+          ) : links.length > 0 ? (
+            <ul className="links-list">
+              {links.map((link) => {
+                const createdAt = formatDate(link.createdAt)
+                const expiresAt = formatDate(link.expiresAt)
+                const isDeleting = deleting.has(link.id)
+                const isCopied = copiedId === link.id
+
+                return (
+                  <li key={link.id} className="link-item">
+                    <div className="link-top-row">
+                      <a
+                        href={link.shortUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="link-short"
+                      >
+                        {link.shortUrl}
+                      </a>
+                      <div className="link-actions">
+                        <button
+                          type="button"
+                          className="ghost-button"
+                          onClick={() => void handleCopy(link)}
+                        >
+                          {isCopied ? 'Скопировано' : 'Копировать'}
+                        </button>
+                        <button
+                          type="button"
+                          className="danger-button"
+                          onClick={() => void handleDelete(link)}
+                          disabled={isDeleting}
+                        >
+                          {isDeleting ? 'Удаление...' : 'Удалить'}
+                        </button>
+                      </div>
+                    </div>
+                    <div className="link-original" title={link.originalUrl}>
+                      {link.originalUrl}
+                    </div>
+                    <div className="link-meta">
+                      {createdAt && <span>Создано: {createdAt}</span>}
+                      {expiresAt && <span>Истекает: {expiresAt}</span>}
+                      {typeof link.clicks === 'number' && (
+                        <span>Переходы: {link.clicks}</span>
+                      )}
+                      <span>Slug: {link.slug}</span>
+                    </div>
+                  </li>
+                )
+              })}
+            </ul>
+          ) : (
+            <p className="empty-state">
+              Пока нет созданных ссылок. Используйте форму выше, чтобы сократить первую ссылку.
+            </p>
+          )}
+        </section>
       </section>
     </main>
   )

--- a/src/api/urlShortener.ts
+++ b/src/api/urlShortener.ts
@@ -1,0 +1,380 @@
+const KNOWN_LIST_ENDPOINTS = [
+  '/api/v1/urls',
+  '/api/v1/short-urls',
+  '/api/v1/links',
+  '/api/urls',
+  '/api/links',
+  '/urls',
+  '/links',
+];
+
+const KNOWN_CREATE_ENDPOINTS = [
+  '/api/v1/urls',
+  '/api/v1/links',
+  '/api/urls',
+  '/api/links',
+  '/urls',
+  '/links',
+  '/shorten',
+];
+
+const KNOWN_DELETE_PATTERNS = [
+  (id: string) => `/api/v1/urls/${id}`,
+  (id: string) => `/api/v1/links/${id}`,
+  (id: string) => `/api/urls/${id}`,
+  (id: string) => `/api/links/${id}`,
+  (id: string) => `/urls/${id}`,
+  (id: string) => `/links/${id}`,
+  (id: string) => `/url/${id}`,
+];
+
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL ?? '').replace(/\/$/, '');
+const SHORT_BASE_URL = (import.meta.env.VITE_SHORT_BASE_URL ?? '').replace(/\/$/, '');
+
+type FetchMethod = 'GET' | 'POST' | 'DELETE';
+
+type FetchResult<T> = {
+  data: T;
+  endpoint: string;
+};
+
+const endpointCache = new Map<string, string>();
+
+const buildUrl = (path: string) => {
+  if (!API_BASE_URL) {
+    return path;
+  }
+
+  if (!path.startsWith('/')) {
+    return `${API_BASE_URL}/${path}`;
+  }
+
+  return `${API_BASE_URL}${path}`;
+};
+
+const pickString = (obj: Record<string, unknown>, keys: string[]): string | undefined => {
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const pickNumber = (obj: Record<string, unknown>, keys: string[]): number | undefined => {
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const tryFetch = async <T>(
+  method: FetchMethod,
+  paths: string[],
+  body?: unknown,
+  preferredKey?: string
+): Promise<FetchResult<T>> => {
+  const cacheKey = `${method}:${preferredKey ?? ''}`;
+  const cachedEndpoint = preferredKey ? endpointCache.get(cacheKey) : undefined;
+
+  if (cachedEndpoint) {
+    const response = await fetch(buildUrl(cachedEndpoint), {
+      method,
+      headers: body ? { 'Content-Type': 'application/json' } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (response.ok) {
+      const data = (await response.json()) as T;
+      return { data, endpoint: cachedEndpoint };
+    }
+  }
+
+  let lastError: unknown;
+
+  for (const path of paths) {
+    try {
+      const response = await fetch(buildUrl(path), {
+        method,
+        headers: body ? { 'Content-Type': 'application/json' } : undefined,
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      if (!response.ok) {
+        if (response.status >= 500) {
+          throw new Error(`Server responded with ${response.status}`);
+        }
+        continue;
+      }
+
+      const data = (await response.json()) as T;
+
+      if (preferredKey) {
+        endpointCache.set(cacheKey, path);
+      }
+
+      return { data, endpoint: path };
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError ?? new Error('Unable to reach URL shortener service');
+};
+
+export type ShortLink = {
+  id: string;
+  slug: string;
+  originalUrl: string;
+  shortUrl: string;
+  createdAt?: string;
+  expiresAt?: string;
+  clicks?: number;
+};
+
+const normaliseDate = (input?: string) => {
+  if (!input) {
+    return undefined;
+  }
+
+  const numericValue = Number(input);
+
+  if (!Number.isNaN(numericValue) && numericValue > 0) {
+    return new Date(numericValue).toISOString();
+  }
+
+  const timestamp = Date.parse(input);
+  if (!Number.isNaN(timestamp)) {
+    return new Date(timestamp).toISOString();
+  }
+
+  return undefined;
+};
+
+const extractShortUrl = (
+  raw: Record<string, unknown>,
+  slug: string
+): string => {
+  const direct = pickString(raw, [
+    'shortUrl',
+    'shortURL',
+    'short_url',
+    'shortLink',
+    'short_link',
+    'short',
+    'shortened',
+  ]);
+
+  if (direct) {
+    return direct;
+  }
+
+  if (SHORT_BASE_URL) {
+    return `${SHORT_BASE_URL}/${slug}`;
+  }
+
+  const inferred = pickString(raw, ['domain', 'host', 'baseUrl']);
+  if (inferred) {
+    return `${inferred.replace(/\/$/, '')}/${slug}`;
+  }
+
+  if (typeof window !== 'undefined' && window.location) {
+    return `${window.location.origin}/${slug}`;
+  }
+
+  return slug;
+};
+
+const parseShortLink = (raw: unknown): ShortLink | null => {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+
+  const record = raw as Record<string, unknown>;
+
+  const slug = pickString(record, [
+    'slug',
+    'shortCode',
+    'code',
+    'short_code',
+    'hash',
+    'id',
+    'shortId',
+    'short_id',
+    'alias',
+    'key',
+  ]);
+
+  const originalUrl = pickString(record, [
+    'originalUrl',
+    'original_url',
+    'original',
+    'destination',
+    'target',
+    'targetUrl',
+    'url',
+    'longUrl',
+    'long_url',
+  ]);
+
+  if (!slug || !originalUrl) {
+    return null;
+  }
+
+  const id = pickString(record, ['id', 'uuid', 'key', 'slug', 'shortId', 'short_id']) ?? slug;
+
+  const shortUrl = extractShortUrl(record, slug);
+
+  const clicks = pickNumber(record, ['clicks', 'visits', 'usageCount', 'count']);
+
+  const createdAt = normaliseDate(
+    pickString(record, ['createdAt', 'created_at', 'created', 'createdDate', 'createdTime'])
+  );
+
+  const expiresAt = normaliseDate(pickString(record, ['expiresAt', 'expires_at', 'expiry', 'expireAt']));
+
+  return { id, slug, originalUrl, shortUrl, clicks, createdAt, expiresAt };
+};
+
+export const fetchShortLinks = async (): Promise<ShortLink[]> => {
+  const { data, endpoint } = await tryFetch<unknown>(
+    'GET',
+    KNOWN_LIST_ENDPOINTS,
+    undefined,
+    'list'
+  );
+
+  endpointCache.set('GET:list', endpoint);
+
+  const items: unknown[] = Array.isArray(data)
+    ? data
+    : typeof data === 'object' && data !== null
+      ? (() => {
+          const container = data as Record<string, unknown>;
+          const possibleCollections = [
+            container.items,
+            container.urls,
+            container.links,
+            container.data,
+            container.results,
+            container.list,
+          ];
+
+          for (const value of possibleCollections) {
+            if (Array.isArray(value)) {
+              return value;
+            }
+          }
+
+          return [] as unknown[];
+        })()
+      : [];
+
+  const parsed = items
+    .map((item) => parseShortLink(item))
+    .filter((item): item is ShortLink => Boolean(item));
+
+  return parsed;
+};
+
+type CreatePayload = {
+  url: string;
+  alias?: string;
+};
+
+const createPayloadVariants = (payload: CreatePayload) => {
+  const variants: Record<string, unknown>[] = [];
+
+  variants.push({ originalUrl: payload.url, alias: payload.alias });
+  variants.push({ url: payload.url, alias: payload.alias });
+  variants.push({ target: payload.url, alias: payload.alias });
+  variants.push({ longUrl: payload.url, alias: payload.alias });
+  variants.push({ original_url: payload.url, alias: payload.alias });
+  variants.push({ url: payload.url, customAlias: payload.alias });
+  variants.push({ url: payload.url, shortCode: payload.alias });
+
+  return variants;
+};
+
+export const createShortLink = async (
+  payload: CreatePayload
+): Promise<ShortLink> => {
+  const variants = createPayloadVariants(payload);
+  let lastError: unknown;
+
+  const cachedEndpoint = endpointCache.get('POST:create');
+  const endpoints = cachedEndpoint ? [cachedEndpoint] : KNOWN_CREATE_ENDPOINTS;
+
+  for (const endpoint of endpoints) {
+    for (const variant of variants) {
+      try {
+        const response = await fetch(buildUrl(endpoint), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(variant),
+        });
+
+        if (!response.ok) {
+          if (response.status >= 500) {
+            throw new Error(`Server responded with ${response.status}`);
+          }
+          continue;
+        }
+
+        const data = await response.json();
+        const parsed = parseShortLink(data);
+
+        if (!parsed) {
+          throw new Error('Unexpected response format from URL shortener');
+        }
+
+        endpointCache.set('POST:create', endpoint);
+
+        return parsed;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+  }
+
+  throw lastError ?? new Error('Unable to create short link');
+};
+
+export const deleteShortLink = async (identifier: string): Promise<void> => {
+  const cachedListEndpoint = endpointCache.get('GET:list');
+  const cachedCreateEndpoint = endpointCache.get('POST:create');
+
+  const dynamicPatterns = [
+    ...(cachedListEndpoint ? [(id: string) => `${cachedListEndpoint}/${id}`] : []),
+    ...(cachedCreateEndpoint ? [(id: string) => `${cachedCreateEndpoint}/${id}`] : []),
+  ];
+
+  const attempts = [...dynamicPatterns, ...KNOWN_DELETE_PATTERNS];
+
+  let lastError: unknown;
+
+  for (const buildPath of attempts) {
+    const path = buildPath(identifier);
+
+    try {
+      const response = await fetch(buildUrl(path), { method: 'DELETE' });
+
+      if (!response.ok) {
+        if (response.status >= 500) {
+          throw new Error(`Server responded with ${response.status}`);
+        }
+        continue;
+      }
+
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError ?? new Error('Unable to delete short link');
+};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,7 +1,19 @@
 /// <reference types="vite/client" />
 
 declare global {
+  interface TelegramThemeParams {
+    bg_color?: string
+    button_color?: string
+    button_text_color?: string
+    secondary_bg_color?: string
+    hint_color?: string
+    text_color?: string
+    [key: string]: string | undefined
+  }
+
   interface TelegramWebApp {
+    themeParams?: TelegramThemeParams
+    ready?: () => void
     [key: string]: unknown
   }
 


### PR DESCRIPTION
## Summary
- add a resilient API client for the url-shortener service that discovers list/create/delete routes and normalises responses
- redesign the mini app UI around managing shortened links with Telegram theme support and clipboard helpers
- extend Telegram type definitions for theme params handling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e42ae057dc8320ac1fe216d43e0af7