### PR TITLE
Refactor URL shortener client for fixed alias endpoints

### DIFF
--- a/src/shared/api/url-shortener.ts
+++ b/src/shared/api/url-shortener.ts
@@ -1,46 +1,7 @@
 import type { ShortLink } from '@/entities/short-link'
 
-const KNOWN_LIST_ENDPOINTS = [
-  '/api/v1/urls',
-  '/api/v1/short-urls',
-  '/api/v1/links',
-  '/api/urls',
-  '/api/links',
-  '/urls',
-  '/links',
-]
-
-const KNOWN_CREATE_ENDPOINTS = [
-  '/api/v1/urls',
-  '/api/v1/links',
-  '/api/urls',
-  '/api/links',
-  '/urls',
-  '/links',
-  '/shorten',
-]
-
-const KNOWN_DELETE_PATTERNS = [
-  (id: string) => `/api/v1/urls/${id}`,
-  (id: string) => `/api/v1/links/${id}`,
-  (id: string) => `/api/urls/${id}`,
-  (id: string) => `/api/links/${id}`,
-  (id: string) => `/urls/${id}`,
-  (id: string) => `/links/${id}`,
-  (id: string) => `/url/${id}`,
-]
-
 const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL ?? '').replace(/\/$/, '')
 const SHORT_BASE_URL = (import.meta.env.VITE_SHORT_BASE_URL ?? '').replace(/\/$/, '')
-
-type FetchMethod = 'GET' | 'POST' | 'DELETE'
-
-type FetchResult<T> = {
-  data: T
-  endpoint: string
-}
-
-const endpointCache = new Map<string, string>()
 
 const buildUrl = (path: string) => {
   if (!API_BASE_URL) {
@@ -54,218 +15,71 @@ const buildUrl = (path: string) => {
   return `${API_BASE_URL}${path}`
 }
 
-const pickString = (obj: Record<string, unknown>, keys: string[]): string | undefined => {
-  for (const key of keys) {
-    const value = obj[key]
-    if (typeof value === 'string' && value.trim().length > 0) {
-      return value
-    }
-  }
-  return undefined
+type AliasResponse = {
+  id: string
+  alias: string
+  url: string
+  shortUrl?: string
+  createdAt?: string
+  expiresAt?: string
+  clicks?: number
 }
 
-const pickNumber = (obj: Record<string, unknown>, keys: string[]): number | undefined => {
-  for (const key of keys) {
-    const value = obj[key]
-    if (typeof value === 'number' && Number.isFinite(value)) {
-      return value
-    }
-  }
-  return undefined
+type AliasListResponse = {
+  items: AliasResponse[]
 }
 
-const tryFetch = async <T>(
-  method: FetchMethod,
-  paths: string[],
-  body?: unknown,
-  preferredKey?: string
-): Promise<FetchResult<T>> => {
-  const cacheKey = `${method}:${preferredKey ?? ''}`
-  const cachedEndpoint = preferredKey ? endpointCache.get(cacheKey) : undefined
-
-  if (cachedEndpoint) {
-    const response = await fetch(buildUrl(cachedEndpoint), {
-      method,
-      headers: body ? { 'Content-Type': 'application/json' } : undefined,
-      body: body ? JSON.stringify(body) : undefined,
-    })
-
-    if (response.ok) {
-      const data = (await response.json()) as T
-      return { data, endpoint: cachedEndpoint }
-    }
-  }
-
-  let lastError: unknown
-
-  for (const path of paths) {
-    try {
-      const response = await fetch(buildUrl(path), {
-        method,
-        headers: body ? { 'Content-Type': 'application/json' } : undefined,
-        body: body ? JSON.stringify(body) : undefined,
-      })
-
-      if (!response.ok) {
-        if (response.status >= 500) {
-          throw new Error(`Server responded with ${response.status}`)
-        }
-        continue
-      }
-
-      const data = (await response.json()) as T
-
-      if (preferredKey) {
-        endpointCache.set(cacheKey, path)
-      }
-
-      return { data, endpoint: path }
-    } catch (error) {
-      lastError = error
-    }
-  }
-
-  throw lastError ?? new Error('Unable to reach URL shortener service')
-}
-
-const normaliseDate = (input?: string) => {
-  if (!input) {
+const ensureIsoDate = (value?: string) => {
+  if (!value) {
     return undefined
   }
 
-  const numericValue = Number(input)
-
-  if (!Number.isNaN(numericValue) && numericValue > 0) {
-    return new Date(numericValue).toISOString()
+  const timestamp = Date.parse(value)
+  if (Number.isNaN(timestamp)) {
+    return undefined
   }
 
-  const timestamp = Date.parse(input)
-  if (!Number.isNaN(timestamp)) {
-    return new Date(timestamp).toISOString()
-  }
-
-  return undefined
+  return new Date(timestamp).toISOString()
 }
 
-const extractShortUrl = (
-  raw: Record<string, unknown>,
-  slug: string
-): string => {
-  const direct = pickString(raw, [
-    'shortUrl',
-    'shortURL',
-    'short_url',
-    'shortLink',
-    'short_link',
-    'short',
-    'shortened',
-  ])
+const mapShortLink = (alias: AliasResponse): ShortLink => {
+  const shortUrl = alias.shortUrl
+    ? alias.shortUrl
+    : SHORT_BASE_URL
+      ? `${SHORT_BASE_URL}/${alias.alias}`
+      : alias.alias
 
-  if (direct) {
-    return direct
+  return {
+    id: alias.id,
+    slug: alias.alias,
+    originalUrl: alias.url,
+    shortUrl,
+    createdAt: ensureIsoDate(alias.createdAt),
+    expiresAt: ensureIsoDate(alias.expiresAt),
+    clicks: alias.clicks,
   }
-
-  if (SHORT_BASE_URL) {
-    return `${SHORT_BASE_URL}/${slug}`
-  }
-
-  const inferred = pickString(raw, ['domain', 'host', 'baseUrl'])
-  if (inferred) {
-    return `${inferred.replace(/\/$/, '')}/${slug}`
-  }
-
-  if (typeof window !== 'undefined' && window.location) {
-    return `${window.location.origin}/${slug}`
-  }
-
-  return slug
 }
 
-const parseShortLink = (raw: unknown): ShortLink | null => {
-  if (!raw || typeof raw !== 'object') {
-    return null
+const readJson = async <T>(response: Response): Promise<T> => {
+  if (!response.ok) {
+    const message = await response.text().catch(() => null)
+    throw new Error(message || `Request failed with status ${response.status}`)
   }
 
-  const record = raw as Record<string, unknown>
-
-  const slug = pickString(record, [
-    'slug',
-    'shortCode',
-    'code',
-    'short_code',
-    'hash',
-    'id',
-    'shortId',
-    'short_id',
-    'alias',
-    'key',
-  ])
-
-  const originalUrl = pickString(record, [
-    'originalUrl',
-    'original_url',
-    'original',
-    'destination',
-    'target',
-    'targetUrl',
-    'url',
-    'longUrl',
-    'long_url',
-  ])
-
-  if (!slug || !originalUrl) {
-    return null
-  }
-
-  const id = pickString(record, ['id', 'uuid', 'key', 'slug', 'shortId', 'short_id']) ?? slug
-
-  const shortUrl = extractShortUrl(record, slug)
-
-  const clicks = pickNumber(record, ['clicks', 'visits', 'usageCount', 'count'])
-
-  const createdAt = normaliseDate(
-    pickString(record, ['createdAt', 'created_at', 'created', 'createdDate', 'createdTime'])
-  )
-
-  const expiresAt = normaliseDate(pickString(record, ['expiresAt', 'expires_at', 'expiry', 'expireAt']))
-
-  return { id, slug, originalUrl, shortUrl, clicks, createdAt, expiresAt }
+  return (await response.json()) as T
 }
 
 export const fetchShortLinks = async (): Promise<ShortLink[]> => {
-  const { data, endpoint } = await tryFetch<unknown>('GET', KNOWN_LIST_ENDPOINTS, undefined, 'list')
+  const response = await fetch(buildUrl('/alias'))
+  const payload = await readJson<AliasResponse[] | AliasListResponse>(response)
 
-  endpointCache.set('GET:list', endpoint)
-
-  const items: unknown[] = Array.isArray(data)
-    ? data
-    : typeof data === 'object' && data !== null
-      ? (() => {
-          const container = data as Record<string, unknown>
-          const possibleCollections = [
-            container.items,
-            container.urls,
-            container.links,
-            container.data,
-            container.results,
-            container.list,
-          ]
-
-          for (const value of possibleCollections) {
-            if (Array.isArray(value)) {
-              return value
-            }
-          }
-
-          return [] as unknown[]
-        })()
+  const list = Array.isArray(payload)
+    ? payload
+    : Array.isArray(payload?.items)
+      ? payload.items
       : []
 
-  const parsed = items
-    .map((item) => parseShortLink(item))
-    .filter((item): item is ShortLink => Boolean(item))
-
-  return parsed
+  return list.map(mapShortLink)
 }
 
 type CreatePayload = {
@@ -273,93 +87,40 @@ type CreatePayload = {
   alias?: string
 }
 
-const createPayloadVariants = (payload: CreatePayload) => {
-  const variants: Record<string, unknown>[] = []
-
-  variants.push({ originalUrl: payload.url, alias: payload.alias })
-  variants.push({ url: payload.url, alias: payload.alias })
-  variants.push({ target: payload.url, alias: payload.alias })
-  variants.push({ longUrl: payload.url, alias: payload.alias })
-  variants.push({ original_url: payload.url, alias: payload.alias })
-  variants.push({ url: payload.url, customAlias: payload.alias })
-  variants.push({ url: payload.url, shortCode: payload.alias })
-
-  return variants
-}
-
 export const createShortLink = async (payload: CreatePayload): Promise<ShortLink> => {
-  const variants = createPayloadVariants(payload)
-  let lastError: unknown
+  const response = await fetch(buildUrl('/alias'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
 
-  const cachedEndpoint = endpointCache.get('POST:create')
-  const endpoints = cachedEndpoint ? [cachedEndpoint] : KNOWN_CREATE_ENDPOINTS
-
-  for (const endpoint of endpoints) {
-    for (const variant of variants) {
-      try {
-        const response = await fetch(buildUrl(endpoint), {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(variant),
-        })
-
-        if (!response.ok) {
-          if (response.status >= 500) {
-            throw new Error(`Server responded with ${response.status}`)
-          }
-          continue
-        }
-
-        const data = await response.json()
-        const parsed = parseShortLink(data)
-
-        if (!parsed) {
-          throw new Error('Unexpected response format from URL shortener')
-        }
-
-        endpointCache.set('POST:create', endpoint)
-
-        return parsed
-      } catch (error) {
-        lastError = error
-      }
-    }
-  }
-
-  throw lastError ?? new Error('Unable to create short link')
+  const data = await readJson<AliasResponse>(response)
+  return mapShortLink(data)
 }
 
-export const deleteShortLink = async (identifier: string): Promise<void> => {
-  const cachedListEndpoint = endpointCache.get('GET:list')
-  const cachedCreateEndpoint = endpointCache.get('POST:create')
+type UpdatePayload = {
+  url: string
+  alias?: string
+}
 
-  const dynamicPatterns = [
-    ...(cachedListEndpoint ? [(id: string) => `${cachedListEndpoint}/${id}`] : []),
-    ...(cachedCreateEndpoint ? [(id: string) => `${cachedCreateEndpoint}/${id}`] : []),
-  ]
+export const updateShortLink = async (id: string, payload: UpdatePayload): Promise<ShortLink> => {
+  const response = await fetch(buildUrl(`/alias/${encodeURIComponent(id)}`), {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
 
-  const attempts = [...dynamicPatterns, ...KNOWN_DELETE_PATTERNS]
+  const data = await readJson<AliasResponse>(response)
+  return mapShortLink(data)
+}
 
-  let lastError: unknown
+export const deleteShortLink = async (id: string): Promise<void> => {
+  const response = await fetch(buildUrl(`/alias/${encodeURIComponent(id)}`), {
+    method: 'DELETE',
+  })
 
-  for (const buildPath of attempts) {
-    const path = buildPath(identifier)
-
-    try {
-      const response = await fetch(buildUrl(path), { method: 'DELETE' })
-
-      if (!response.ok) {
-        if (response.status >= 500) {
-          throw new Error(`Server responded with ${response.status}`)
-        }
-        continue
-      }
-
-      return
-    } catch (error) {
-      lastError = error
-    }
+  if (!response.ok) {
+    const message = await response.text().catch(() => null)
+    throw new Error(message || `Request failed with status ${response.status}`)
   }
-
-  throw lastError ?? new Error('Unable to delete short link')
 }


### PR DESCRIPTION
## Summary
- replace the dynamic endpoint discovery with fixed `/alias` REST calls
- map alias responses to `ShortLink` objects and provide update support

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e57488a3888320857885862ddc7f72